### PR TITLE
prevent printing of the buttons and descriptive text

### DIFF
--- a/print.css
+++ b/print.css
@@ -1,0 +1,3 @@
+#socialshareprivacy {
+    display:none;
+}


### PR DESCRIPTION
The whole toolbar takes about half a page when printed which is rather wasteful, this pull turns off the display of the whole toolbar when printed.

see this in action at http://www.hooidonksekanoclub.nl/dokuwiki/start
